### PR TITLE
Add reading and writing to yaml files with Jackson

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,8 @@ subprojects {
     dependencies {
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
+        testCompile group: 'org.mockito', name: 'mockito-core', version: '3.2.4'
+        testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.2.4'
     }
 
     test {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.2'
+    compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.10.2'
+}

--- a/core/src/main/java/projectzero/UMLClass.java
+++ b/core/src/main/java/projectzero/UMLClass.java
@@ -2,12 +2,18 @@ package projectzero;
 
 public class UMLClass {
     private String name;
-    public UMLClass(String name){
+
+    public UMLClass() {
+    }
+
+    public UMLClass(String name) {
         this.name = name;
     }
+
     public String getName() {
         return name;
     }
+
     public void setName(String name) {
         this.name = name;
     }

--- a/core/src/main/java/projectzero/UMLClassManager.java
+++ b/core/src/main/java/projectzero/UMLClassManager.java
@@ -1,12 +1,21 @@
 package projectzero;
 
-import java.util.LinkedList;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 public class UMLClassManager {
-    private LinkedList<UMLClass> classList;
+    private List<UMLClass> classList;
+    private UMLClassYamlMapper umlClassYamlMapper;
 
     public UMLClassManager() {
-        classList = new LinkedList<UMLClass>();
+        this.classList = new ArrayList<>();
+        umlClassYamlMapper = new UMLClassYamlMapper();
+    }
+
+    public UMLClassManager(UMLClassYamlMapper umlClassYamlMapper) {
+        this.classList = new ArrayList<>();
+        this.umlClassYamlMapper = umlClassYamlMapper;
     }
 
     public boolean addClass(UMLClass newClass) {
@@ -42,15 +51,27 @@ public class UMLClassManager {
         //What happens if the classObject is not found?
     }
 
-    public void saveWork(String path) {
 
-    }
-
-    public void loadWork(String path) {
-
-    }
-
-    public LinkedList<UMLClass> getClassList() {
+    public List<UMLClass> getClassList() {
         return classList;
     }
+
+    public boolean save(String path) {
+        try {
+            umlClassYamlMapper.write(path, this.classList);
+            return true;
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+
+    public boolean load(String path) {
+        try {
+            this.classList = umlClassYamlMapper.read(path);
+            return true;
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+
 }

--- a/core/src/main/java/projectzero/UMLClassYamlMapper.java
+++ b/core/src/main/java/projectzero/UMLClassYamlMapper.java
@@ -1,0 +1,22 @@
+package projectzero;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class UMLClassYamlMapper {
+    public List<UMLClass> read(String fileName) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        return objectMapper.readValue(new File(fileName), new TypeReference<>() {
+        });
+    }
+
+    public void write(String fileName, List<UMLClass> umlClassList) throws IOException {
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+        objectMapper.writeValue(new File(fileName), umlClassList);
+    }
+}

--- a/core/src/test/java/projectzero/UMLClassManagerTest.java
+++ b/core/src/test/java/projectzero/UMLClassManagerTest.java
@@ -2,7 +2,17 @@ package projectzero;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 public class UMLClassManagerTest {
 
     @Test
@@ -63,4 +73,39 @@ public class UMLClassManagerTest {
         Assertions.assertEquals("project", umlClass.getName());
     }
 
+    @Test
+    public void testLoadReturnsTrueOnSuccess(@Mock UMLClassYamlMapper umlClassYamlMapper) throws IOException {
+        when(umlClassYamlMapper.read(anyString())).thenReturn(anyList());
+
+        UMLClassManager umlClassManager = new UMLClassManager(umlClassYamlMapper);
+
+        Assertions.assertTrue(umlClassManager.load("test.yaml"));
+    }
+
+    @Test
+    public void testLoadReturnsFalseOnFailure(@Mock UMLClassYamlMapper umlClassYamlMapper) throws IOException {
+        doThrow(IOException.class).when(umlClassYamlMapper).read(anyString());
+
+        UMLClassManager umlClassManager = new UMLClassManager(umlClassYamlMapper);
+
+        Assertions.assertFalse(umlClassManager.load("test.yaml"));
+    }
+
+    @Test
+    public void testSaveReturnsTrueOnSuccess(@Mock UMLClassYamlMapper umlClassYamlMapper) throws IOException {
+        doNothing().when(umlClassYamlMapper).write(anyString(), anyList());
+
+        UMLClassManager umlClassManager = new UMLClassManager(umlClassYamlMapper);
+
+        Assertions.assertTrue(umlClassManager.save("test.yaml"));
+    }
+
+    @Test
+    public void testSaveReturnsFalseOnFailure(@Mock UMLClassYamlMapper umlClassYamlMapper) throws IOException {
+        doThrow(IOException.class).when(umlClassYamlMapper).write(anyString(), anyList());
+
+        UMLClassManager umlClassManager = new UMLClassManager(umlClassYamlMapper);
+
+        Assertions.assertFalse(umlClassManager.save("test.yaml"));
+    }
 }

--- a/core/src/test/java/projectzero/UMLClassYamlMapperTest.java
+++ b/core/src/test/java/projectzero/UMLClassYamlMapperTest.java
@@ -1,0 +1,33 @@
+package projectzero;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class UMLClassYamlMapperTest {
+
+    @Test
+    void testReadsAndWritesClassesToFile(@TempDir Path tempDir) throws IOException {
+        Path path = tempDir.resolve("animals.yaml");
+
+        UMLClass dog = new UMLClass("dog");
+        UMLClass cat = new UMLClass("cat");
+        UMLClass bat = new UMLClass("bat");
+
+        List<UMLClass> animals = Arrays.asList(dog, cat, bat);
+
+        UMLClassYamlMapper umlClassYamlMapper = new UMLClassYamlMapper();
+        umlClassYamlMapper.write(path.toString(), animals);
+
+        List<String> animalNames = animals.stream().map(animal -> animal.getName()).collect(Collectors.toList());
+        List<String> readAnimalNames = umlClassYamlMapper.read(path.toString()).stream().map(animal -> animal.getName()).collect(Collectors.toList());
+
+        Assertions.assertArrayEquals(animalNames.toArray(), readAnimalNames.toArray());
+    }
+}


### PR DESCRIPTION
### Implementation
Add UMLClassYamlMapper to contain Jackson wrappers fro read and write. Utilize Jackson ObjectMapper to convert POJOs into JSON/YAML. The POJOs must have proper getters and setters and a default constructor for the mapping to occur. 

In UMLClassManager, the save and load methods utilize UMLClassYamlMapper to do file operations. The UMLClassYamlMapper methods throw IOExceptions, so those are handled in the UMLClassManager methods. Both read and write return true on a successful operation and false on a failed operation. 

### Tests
100% Coverage 

Mockito is used in UMLClassManager save/load tests to mock the implementations of UMLClassYamlMapper read/write. UMLClassYamlMapper read/write tests use a TempDir to perform file operations on. 

### Resources
[jackson](https://github.com/FasterXML/jackson)
[jackson-datatype-text/yaml](https://github.com/FasterXML/jackson-dataformats-text/tree/master/yaml)
[mockito](https://site.mockito.org)
[tempDir](https://junit.org/junit5/docs/5.4.0-M1/api/org/junit/jupiter/api/support/io/TempDirectory.TempDir.html)